### PR TITLE
Update other.yml

### DIFF
--- a/_data/other.yml
+++ b/_data/other.yml
@@ -71,6 +71,14 @@ websites:
       img: azendoo.png
       tfa: No
       twitter: Azendoo
+      
+    - name: BasisCode Compliance
+      url: http://basiscode.com
+      img: http://basiscode.com/wp-content/uploads/2016/10/BasisCode-Compliance.png
+      tfa: Yes
+      sms: Yes
+      email: Yes
+      phone: Yes
 
     - name: Bugzilla@Mozilla
       url: https://bugzilla.mozilla.org


### PR DESCRIPTION
BasisCode Compliance cloud software uses 2 factor authentication. We hide the url to prevent spiders from accessing it. The url is https://compliance.basiscode.com